### PR TITLE
docs: update README and CLAUDE.MD for multi-driver DB + queue

### DIFF
--- a/CLAUDE.MD
+++ b/CLAUDE.MD
@@ -9,12 +9,13 @@ This document provides Claude Code with essential context about the ichi-go proj
 **Tech Stack:**
 - Go 1.24+
 - Echo v4 (HTTP framework)
-- Bun ORM (MySQL dialect)
+- Bun ORM (MySQL + PostgreSQL dialects)
 - Redis (caching with LZ4 compression)
-- RabbitMQ (message queue)
+- RabbitMQ (optional — AMQP queue driver)
+- riverqueue/river (optional — Postgres-backed queue driver)
 - samber/do (dependency injection)
 - Viper (configuration management)
-- Goose (SQL migrations)
+- Goose (SQL migrations, auto-detects MySQL/Postgres dialect)
 
 ## Architecture Patterns
 
@@ -34,9 +35,14 @@ internal/
 │       ├── models/       # Domain entities
 │       └── register.go   # DI setup with samber/do
 ├── infra/                # Infrastructure layer
-│   ├── database/        # Bun ORM setup
+│   ├── database/        # Bun ORM (MySQL + Postgres)
 │   ├── cache/           # Redis client
-│   ├── queue/           # RabbitMQ integration
+│   ├── queue/           # Driver-agnostic queue layer
+│   │   ├── interfaces.go  # Dispatcher, JobArgs, ConsumeFunc
+│   │   ├── options.go     # DispatchOption helpers
+│   │   ├── dispatcher.go  # NewDispatcher factory (amqp | database)
+│   │   ├── rabbitmq/      # AMQP producer/consumer
+│   │   └── river/         # River BridgeWorker (Postgres-backed)
 │   └── authz/           # Casbin RBAC enforcer, adapter, cache, watcher
 └── middlewares/         # HTTP middlewares
 ```
@@ -122,41 +128,52 @@ if err := validator.BindAndValidate(c, &req); err != nil {
 }
 ```
 
-### 3. Message Queue (RabbitMQ)
+### 3. Message Queue
 
 Location: `internal/infra/queue/`
 
-**Consumer Registration:**
-```go
-// In internal/infra/queue/registry.go
-func init() {
-    RegisterConsumer(ConsumerRegistration{
-        Name: "handler_name",
-        Description: "Handler description",
-        ConsumeFunc: func(ctx context.Context, msg rabbitmq.Message) error {
-            // Process message
-            return nil
-        },
-    })
-}
-```
+The queue layer is driver-agnostic via `queue.Dispatcher`. Configure `queue.default` to `"amqp"` (RabbitMQ) or `"database"` (River on Postgres).
 
-**Publishing Messages:**
+**Consumer Registration (works for both drivers):**
 ```go
-producer.Publish(ctx, rabbitmq.PublishParams{
-    RoutingKey: "event.name",
-    Body: data,
+// In any domain init or register.go
+queue.RegisterConsumer(queue.ConsumerRegistration{
+    Name:        "handler_name",
+    Description: "Handler description",
+    ConsumeFunc: func(ctx context.Context, payload []byte) error {
+        // Process message
+        return nil
+    },
 })
 ```
 
+**Dispatching Jobs:**
+```go
+// Inject the driver-agnostic dispatcher
+dispatcher := do.MustInvoke[queue.Dispatcher](injector)
+
+// Dispatch with options
+dispatcher.Dispatch(ctx, myJob,
+    queue.WithDelay(5*time.Minute),         // schedule delay (both drivers)
+    queue.WithMaxAttempts(3),               // River only
+    queue.WithPriority(1),                  // River only
+)
+```
+
 **Important Notes:**
+- AMQP dispatcher validates and rejects `Queue`/`MaxAttempts`/`Priority` options — use only `Delay`
+- River dispatcher supports all options via `riverqueue.InsertOpts`
 - Always handle context cancellation for graceful shutdown
 - Return error for retryable failures, nil for permanent failures
-- Configure consumers in `config.*.yaml` under `queue.rabbitmq.consumers`
+- Consumer registrations must have **unique names** — duplicates panic at startup
 
 ### 4. Database & Bun ORM
 
 Location: `internal/infra/database/`
+
+**Named connections** — `database.connections` is a map; each entry becomes a named `*bun.DB` in DI. The `database.default` key points to the unnamed `*bun.DB` alias used by all existing repositories.
+
+**Supported drivers:** `mysql`, `postgres`
 
 **Base Repository Pattern:**
 ```go
@@ -164,7 +181,7 @@ type UserRepository struct {
     *bun.BaseRepository[models.User]
 }
 
-func NewUserRepository(db *database.DB) *UserRepository {
+func NewUserRepository(db *bun.DB) *UserRepository {
     return &UserRepository{
         BaseRepository: bun.NewBaseRepository[models.User](db),
     }
@@ -182,6 +199,7 @@ func NewUserRepository(db *database.DB) *UserRepository {
 - Schema migrations: `db/migrations/schema/`
 - Data migrations: `db/migrations/data/`
 - Seeds: `db/migrations/seeds/`
+- Migration CLI (`db/cmd/migrate.go`) auto-detects driver from config and calls the correct DSN builder and Goose dialect
 - See Makefile for all migration commands
 
 ### 5. Caching (Redis)
@@ -411,13 +429,15 @@ logger.WithContext(ctx).Info("Processing request")
 ### Entry Points
 - `cmd/main.go` - Application entry point
 - `cmd/server/rest_server.go` - HTTP server setup
-- `cmd/server/queue_server.go` - RabbitMQ workers
+- `cmd/server/queue_server.go` - Queue workers (AMQP + River, selected by driver)
 - `cmd/server/web_server.go` - Web/template routes
 
 ### Infrastructure
-- `internal/infra/database/database.go` - Database connection
+- `internal/infra/database/database.go` - MySQL + Postgres connection factories
 - `internal/infra/cache/cache.go` - Redis connection
-- `internal/infra/queue/rabbitmq/` - RabbitMQ implementation
+- `internal/infra/queue/` - Driver-agnostic queue layer
+  - `rabbitmq/` - AMQP producer/consumer implementation
+  - `river/` - River BridgeWorker for Postgres-backed jobs
 
 ### Utilities
 - `pkg/authenticator/` - JWT implementation
@@ -479,18 +499,21 @@ go test -cover ./...        # With coverage
 ## Troubleshooting
 
 ### Database Connection Issues
-- Check `database` config in config.yaml
+- Check `database.connections.<name>` config in config.yaml
 - Verify MySQL is running: `mysql -u root -p`
+- Verify Postgres is running: `psql -U postgres`
 - Run migrations: `make migration-up`
+- `config.Database()` panics with descriptive message if `database.default` key doesn't exist in `connections` — check the `default:` value matches a connection name
 
 ### Redis Connection Issues
 - Check `cache` config in config.yaml
 - Verify Redis is running: `redis-cli ping`
 
-### RabbitMQ Issues
-- Check `queue.rabbitmq` config
-- Verify RabbitMQ is running: `rabbitmqctl status`
-- Check exchange setup in config.yaml
+### RabbitMQ / Queue Issues
+- AMQP: check `queue.connections.amqp` config and verify RabbitMQ is running: `rabbitmqctl status`
+- River: check `queue.connections.database.database.connection` points to a valid Postgres connection
+- Health endpoint (`/health`) shows per-component status; RabbitMQ checker only appears when AMQP connection is active
+- Duplicate consumer names cause startup failure — check `queue.RegisterConsumer` calls
 
 ### Validation Not Working
 - Check validator registration in domain's validators/
@@ -512,10 +535,11 @@ go test -cover ./...        # With coverage
 4. Update Swagger docs if enabled
 
 ### Adding New Queue Consumer
-1. Register in `internal/infra/queue/registry.go`
-2. Add consumer config in `config.*.yaml`
-3. Implement handler function with context support
-4. Test graceful shutdown
+1. Register via `queue.RegisterConsumer` in your domain's `providers.go` or an `init()` block
+2. If using AMQP: add consumer config in `config.*.yaml` under `queue.connections.amqp.rabbitmq.consumers`
+3. If using River: no extra config needed — the `BridgeWorker` routes jobs by `ConsumerName` automatically
+4. Consumer names must be **globally unique** — duplicates are caught at startup
+5. Implement handler with context support and test graceful shutdown
 
 ### Modifying Database Schema
 1. Create migration: `make migration-create name=`

--- a/README.MD
+++ b/README.MD
@@ -11,8 +11,9 @@ A production-ready Go backend template built on clean architecture principles, d
 - **Clean Architecture**: Domain-driven design with clear separation of concerns
 - **Production Ready**: JWT auth, validation, logging, error handling out of the box
 - **Developer Experience**: CLI generators, hot reload, comprehensive examples
-- **Message Queue**: RabbitMQ integration with graceful shutdown and worker management
-- **Database**: Bun ORM with migration system and seeding support
+- **Multi-driver Queue**: RabbitMQ (AMQP) and PostgreSQL/River backends — switchable via config
+- **Multi-driver Database**: Named connection map supports MySQL and PostgreSQL via Bun ORM
+- **Migrations**: Goose with auto-detected driver (MySQL or Postgres dialect)
 - **Caching**: Redis with LZ4 compression
 - **Validation**: Multilingual support (English/Indonesian) with custom validators
 - **Observability**: Structured logging with zerolog, request tracing
@@ -36,17 +37,19 @@ A production-ready Go backend template built on clean architecture principles, d
 ### Core Framework
 - **Go 1.24+** - Primary language
 - **Echo v4** - HTTP framework
-- **Bun ORM** - Database operations with MySQL dialect
+- **Bun ORM** - Database operations (MySQL + PostgreSQL dialects)
 - **Viper** - Type-safe configuration management
 
 ### Infrastructure
 - **Redis** - Caching with LZ4 compression
-- **RabbitMQ** - Message queue with topic exchanges
-- **MySQL** - Primary database
+- **RabbitMQ** (optional) - AMQP message queue with topic exchanges
+- **MySQL** - Primary relational database
+- **PostgreSQL** (optional) - Alternate database / River queue backend
+- **riverqueue/river** (optional) - DB-backed reliable job queue on Postgres
 
 ### Developer Tools
 - **Air** - Hot reload for development
-- **Goose** - SQL migrations
+- **Goose** - SQL migrations (auto-detects MySQL / Postgres dialect)
 - **samber/do** - Runtime dependency injection
 - **Mockery** - Interface mocking for tests
 
@@ -85,9 +88,14 @@ make docker-deploy
 ```bash
 # Required
 go >= 1.24
-mysql >= 8.0
 redis >= 7.0
-rabbitmq >= 3.12 (optional, if queue.enabled = true)
+
+# At least one of:
+mysql >= 8.0          # default primary DB
+postgres >= 15        # if using Postgres DB or River queue backend
+
+# Optional
+rabbitmq >= 3.12      # if queue.connections.amqp.enabled = true
 
 # Development tools
 make
@@ -107,18 +115,31 @@ air  # for hot reload
 ```yaml
    # config.local.yaml
    database:
-     host: "localhost"
-     port: 3306
-     user: "your_user"
-     password: "your_password"
-     name: "your_database"
-   
+     default: "mysql"          # or "postgres"
+     connections:
+       mysql:
+         host: "localhost"
+         port: 3306
+         user: "your_user"
+         password: "your_password"
+         name: "your_database"
+       # postgres:             # uncomment for Postgres / River queue
+       #   host: "localhost"
+       #   port: 5432
+       #   user: "postgres"
+       #   name: "your_database"
+
    cache:
      host: "localhost"
      port: 6379
-   
+
    queue:
-     enabled: true  # Set false if RabbitMQ not needed
+     default: "amqp"           # or "database" for River/Postgres
+     connections:
+       amqp:
+         enabled: false        # set true if RabbitMQ is available
+       database:
+         enabled: false        # set true to use River on Postgres
 ```
 
 3. **Install dependencies**
@@ -153,7 +174,7 @@ ichi-go/
 │   ├── main.go                    # Application entry point
 │   ├── server/
 │   │   ├── rest_server.go        # HTTP routes setup
-│   │   ├── queue_server.go       # RabbitMQ workers
+│   │   ├── queue_server.go       # Queue workers (AMQP + River)
 │   │   └── web_server.go         # Web/template routes
 │   └── validator/
 │       └── setup.go              # Validator initialization
@@ -165,19 +186,19 @@ ichi-go/
 │   │   ├── notification/        # Notification service (blast + user-specific)
 │   │   └── rbac/                # Role-based access control (36 endpoints)
 │   ├── infra/                   # Infrastructure layer
-│   │   ├── database/           # Bun ORM setup
+│   │   ├── database/           # Bun ORM (MySQL + Postgres)
 │   │   ├── cache/              # Redis client
-│   │   ├── queue/              # RabbitMQ integration
-│   │   │   ├── rabbitmq/
-│   │   │   │   ├── connection.go
-│   │   │   │   ├── producer.go
-│   │   │   │   └── consumer.go
-│   │   │   └── registry.go     # Consumer registration
+│   │   ├── queue/              # Driver-agnostic queue layer
+│   │   │   ├── interfaces.go   # Dispatcher, JobArgs, ConsumeFunc
+│   │   │   ├── options.go      # DispatchOption helpers
+│   │   │   ├── dispatcher.go   # NewDispatcher factory (amqp | database)
+│   │   │   ├── rabbitmq/       # AMQP producer/consumer
+│   │   │   └── river/          # River worker pool (Postgres-backed)
 │   │   └── authz/              # Casbin RBAC enforcer, adapter, cache, watcher
 │   └── middlewares/            # HTTP middlewares
 ├── db/
 │   ├── cmd/
-│   │   └── migrate.go          # Migration CLI
+│   │   └── migrate.go          # Migration CLI (auto-detects MySQL/Postgres)
 │   └── migrations/
 │       ├── schema/             # Schema migrations
 │       ├── data/               # Data migrations
@@ -251,32 +272,37 @@ if err := validator.BindAndValidate(c, &req); err != nil {
 - `Accept-Language` header
 - Falls back to configured default
 
-### 3. Message Queue (RabbitMQ)
+### 3. Message Queue
 
-Producer/Consumer pattern with graceful shutdown:
+Driver-agnostic `queue.Dispatcher` interface — configure AMQP (RabbitMQ) or database (River on Postgres) via `queue.default`:
+
 ```go
-// Register consumer
+// Register consumer (works for both drivers)
 queue.RegisterConsumer(queue.ConsumerRegistration{
-    Name: "payment_handler",
+    Name:        "payment_handler",
     Description: "Processes payment events",
-    ConsumeFunc: func(ctx context.Context, msg rabbitmq.Message) error {
+    ConsumeFunc: func(ctx context.Context, payload []byte) error {
         // Process message
         return nil
     },
 })
 
-// Publish message
-producer.Publish(ctx, rabbitmq.PublishParams{
-    RoutingKey: "payment.completed",
-    Body: paymentData,
-})
+// Dispatch a job (driver-agnostic)
+dispatcher.Dispatch(ctx, myJob,
+    queue.WithDelay(5*time.Minute),  // schedule delay
+)
 ```
 
-**Features:**
+**AMQP (RabbitMQ) backend:**
 - Topic-based routing with delayed message support
 - Configurable worker pools per consumer
 - Automatic reconnection handling
-- Context-based lifecycle management
+
+**Database (River) backend:**
+- Postgres-backed reliable job queue
+- Poll-based worker with configurable concurrency
+- Supports `Queue`, `MaxAttempts`, `Priority` insert options
+- Shares the existing Bun `*sql.DB` connection — no extra pool needed
 
 ### 4. Dependency Injection with samber/do
 
@@ -499,12 +525,23 @@ http:
   cors:
     allow_origins: ["*"]
 
+# Named connection map — add as many drivers as needed
 database:
-  driver: "mysql"
-  host: "localhost"
-  port: 3306
-  max_idle_conns: 10
-  max_open_conns: 100
+  default: "mysql"              # which connection is the primary *bun.DB
+  connections:
+    mysql:
+      driver: "mysql"
+      host: "localhost"
+      port: 3306
+      name: "ichi_app"
+      max_idle_conns: 10
+      max_open_conns: 100
+    # postgres:                 # uncomment for Postgres / River
+    #   driver: "postgres"
+    #   host: "localhost"
+    #   port: 5432
+    #   name: "ichi_app"
+    #   ssl_mode: "disable"
 
 cache:
   driver: "redis"
@@ -515,20 +552,32 @@ validator:
   default_language: "en"
   supported_languages: ["en", "id"]
 
+# Multi-driver queue — enable one or both backends
 queue:
-  enabled: true
-  rabbitmq:
-    exchanges:
-      - name: "app.events"
-        type: "x-delayed-message"
-    consumers:
-      - name: "payment_handler"
-        queue:
-          name: "order.payment.events"
-        routing_keys:
-          - "payment.completed"
-        prefetch_count: 50
-        worker_pool_size: 10
+  default: "amqp"               # active dispatcher; "database" for River
+  connections:
+    amqp:
+      enabled: false
+      driver: "amqp"
+      rabbitmq:
+        exchanges:
+          - name: "app.events"
+            type: "x-delayed-message"
+        consumers:
+          - name: "payment_handler"
+            queue:
+              name: "order.payment.events"
+            routing_keys:
+              - "payment.completed"
+            prefetch_count: 50
+            worker_pool_size: 10
+    database:
+      enabled: false
+      driver: "database"
+      database:
+        connection: "postgres"   # must match a key in database.connections
+        max_workers: 50
+        poll_interval: 1s
 ```
 
 ## 🧪 Testing

--- a/README.MD
+++ b/README.MD
@@ -137,7 +137,7 @@ air  # for hot reload
      default: "amqp"           # or "database" for River/Postgres
      connections:
        amqp:
-         enabled: false        # set true if RabbitMQ is available
+         enabled: true         # set true if RabbitMQ is available
        database:
          enabled: false        # set true to use River on Postgres
 ```
@@ -557,7 +557,7 @@ queue:
   default: "amqp"               # active dispatcher; "database" for River
   connections:
     amqp:
-      enabled: false
+      enabled: true
       driver: "amqp"
       rabbitmq:
         exchanges:


### PR DESCRIPTION
Covers dual-database config (named map), bun pgdialect wiring,
River queue with Laravel-like dispatch API, RabbitMQ kept as
selectable driver, and Phase B migration notes.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Replaced RabbitMQ-specific queue docs with a driver-agnostic queue layer and unified dispatcher/ConsumeFunc examples.
  * Documented dispatcher options (delay/attempts/priority) and driver-specific validation differences.
  * Added guidance for driver-based queue configuration (AMQP/River), enforcing globally unique consumer names.
  * Expanded DB docs to named connections with default alias (MySQL/Postgres), updated migration CLI and troubleshooting/health endpoint notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->